### PR TITLE
Implement header chunk read

### DIFF
--- a/cogdumper/cog_tiles.py
+++ b/cogdumper/cog_tiles.py
@@ -1,5 +1,7 @@
 """Function for extracting tiff tiles."""
 
+import os
+
 from abc import abstractmethod
 from math import ceil
 import struct
@@ -214,7 +216,8 @@ class COGTiff:
 
     def read_header(self):
         """Read and parse COG header."""
-        self.header = self.read(0, 1024)
+        buff_size = int(os.environ.get('COG_INGESTED_BYTES_AT_OPEN', '16384'))
+        self.header = self.read(0, buff_size)
 
         # read first 4 bytes to determine tiff or bigtiff and byte order
         if self.header[:2] == b'MM':

--- a/cogdumper/cog_tiles.py
+++ b/cogdumper/cog_tiles.py
@@ -71,23 +71,23 @@ class COGTiff:
             pos = 0
             tags = []
 
-            fallbackSize = 4048 if self._big_tiff else 1024
+            fallback_size = 4096 if self._big_tiff else 1024
             if self._offset > len(self.header):
-                bstarts = len(self.header)
-                bends = bstarts + self._offset + fallbackSize
-                self.header += self.read(bstarts, bends)
+                byte_starts = len(self.header)
+                byte_ends = byte_starts + self._offset + fallback_size
+                self.header += self.read(byte_starts, byte_ends)
 
             if self._big_tiff:
                 bytes = self.header[self._offset: self._offset + 8]
                 num_tags = struct.unpack(f'{self._endian}Q', bytes)[0]
 
-                bstarts = self._offset + 8
-                bends = (num_tags * 20) + 8 + bstarts
-                if bends > len(self.header):
+                byte_starts = self._offset + 8
+                byte_ends = (num_tags * 20) + 8 + byte_starts
+                if byte_ends > len(self.header):
                     s = len(self.header)
-                    self.header += self.read(s, bends)
+                    self.header += self.read(s, byte_ends)
 
-                bytes = self.header[bstarts: bends]
+                bytes = self.header[byte_starts: byte_ends]
 
                 for t in range(0, num_tags):
                     code = struct.unpack(
@@ -117,12 +117,13 @@ class COGTiff:
                                 bytes[pos + 12: pos + 20]
                             )[0]
 
-                            bstarts = data_offset
-                            bends = data_offset + tag_len
-                            if bends > len(self.header):
+                            byte_starts = data_offset
+                            byte_ends = byte_starts + tag_len
+                            if byte_ends > len(self.header):
                                 s = len(self.header)
-                                self.header += self.read(s, bends)
-                            data = self.header[bstarts: bends]
+                                self.header += self.read(s, byte_ends)
+
+                            data = self.header[byte_starts: byte_ends]
 
                         tags.append(
                             {
@@ -144,12 +145,13 @@ class COGTiff:
                 bytes = self.header[self._offset: self._offset + 2]
                 num_tags = struct.unpack(f'{self._endian}H', bytes)[0]
 
-                bstarts = self._offset + 2
-                bends = (num_tags * 12) + 2 + bstarts
-                if bends > len(self.header):
+                byte_starts = self._offset + 2
+                byte_ends = (num_tags * 12) + 2 + byte_starts
+                if byte_ends > len(self.header):
                     s = len(self.header)
-                    self.header += self.read(s, bends)
-                bytes = self.header[bstarts: bends]
+                    self.header += self.read(s, byte_ends)
+
+                bytes = self.header[byte_starts: byte_ends]
 
                 for t in range(0, num_tags):
                     code = struct.unpack(
@@ -179,12 +181,12 @@ class COGTiff:
                                 bytes[pos + 8: pos + 12]
                             )[0]
 
-                            bstarts = data_offset
-                            bends = data_offset + tag_len
-                            if bends > len(self.header):
+                            byte_starts = data_offset
+                            byte_ends = byte_starts + tag_len
+                            if byte_ends > len(self.header):
                                 s = len(self.header)
-                                self.header += self.read(s, bends)
-                            data = self.header[bstarts: bends]
+                                self.header += self.read(s, byte_ends)
+                            data = self.header[byte_starts: byte_ends]
 
                         tags.append(
                             {

--- a/cogdumper/cog_tiles.py
+++ b/cogdumper/cog_tiles.py
@@ -179,7 +179,6 @@ class COGTiff:
                                 bytes[pos + 8: pos + 12]
                             )[0]
 
-                            # TODO Check if we need to expend the buffer
                             bstarts = data_offset
                             bends = data_offset + tag_len
                             if bends > len(self.header):

--- a/cogdumper/filedumper.py
+++ b/cogdumper/filedumper.py
@@ -1,6 +1,9 @@
 """A utility to dump tiles directly from a local tiff file."""
 
+import logging
 from cogdumper.cog_tiles import AbstractReader
+
+logger = logging.getLogger(__name__)
 
 
 class Reader(AbstractReader):
@@ -10,5 +13,8 @@ class Reader(AbstractReader):
         self._handle = handle
 
     def read(self, offset, length):
+        start = offset
+        stop = offset + length - 1
+        logger.info(f'Reading bytes: {start} to {stop}')
         self._handle.seek(offset)
         return self._handle.read(length)

--- a/cogdumper/httpdumper.py
+++ b/cogdumper/httpdumper.py
@@ -1,10 +1,14 @@
 """A utility to dump tiles directly from a tiff file on a http server."""
 
+import logging
+
 import requests
 from requests.auth import HTTPBasicAuth
 
 from cogdumper.errors import TIFFError
 from cogdumper.cog_tiles import AbstractReader
+
+logger = logging.getLogger(__name__)
 
 
 class Reader(AbstractReader):
@@ -37,6 +41,7 @@ class Reader(AbstractReader):
     def read(self, offset, length):
         start = offset
         stop = offset + length - 1
+        logger.info(f'Reading bytes: {start} to {stop}')
         headers = {'Range': f'bytes={start}-{stop}'}
         r = self.session.get(self.url, auth=self.auth, headers=headers)
         if r.status_code != requests.codes.partial_content:

--- a/cogdumper/s3dumper.py
+++ b/cogdumper/s3dumper.py
@@ -14,12 +14,14 @@ class Reader(AbstractReader):
     """Wraps the remote COG."""
 
     def __init__(self, bucket_name, key):
+        """Init reader object."""
         self.bucket = bucket_name
         self.key = key
+        self.source = s3.Object(self.bucket, self.key)
 
     def read(self, offset, length):
+        """Read method."""
         start = offset
         stop = offset + length - 1
-        r = s3.meta.client.get_object(Bucket=self.bucket, Key=self.key,
-                                      Range=f'bytes={start}-{stop}')
+        r = self.source.get(Range=f'bytes={start}-{stop}')
         return r['Body'].read()

--- a/cogdumper/s3dumper.py
+++ b/cogdumper/s3dumper.py
@@ -1,10 +1,13 @@
 """A utility to dump tiles directly from a tiff file in an S3 bucket."""
 
 import os
+import logging
 
 import boto3
 
 from cogdumper.cog_tiles import AbstractReader
+
+logger = logging.getLogger(__name__)
 
 region = os.environ.get('AWS_REGION', 'us-east-1')
 s3 = boto3.resource('s3', region_name=region)
@@ -23,5 +26,6 @@ class Reader(AbstractReader):
         """Read method."""
         start = offset
         stop = offset + length - 1
+        logger.info(f'Reading bytes: {start} to {stop}')
         r = self.source.get(Range=f'bytes={start}-{stop}')
         return r['Body'].read()

--- a/cogdumper/scripts/cli.py
+++ b/cogdumper/scripts/cli.py
@@ -1,5 +1,5 @@
 """cli."""
-
+import logging
 import mimetypes
 
 import click
@@ -25,8 +25,13 @@ def cogdumper():
               help='local output directory')
 @click.option('--xyz', type=click.INT, default=[0, 0, 0], nargs=3,
               help='xyz tile coordinates where z is the overview level')
-def s3(bucket, key, output, xyz):
+@click.option('--verbose', '-v', is_flag=True, help='Show logs')
+@click.version_option(version=cogdumper_version, message='%(version)s')
+def s3(bucket, key, output, xyz, verbose):
     """Read AWS S3 hosted dataset."""
+    if verbose:
+        logging.basicConfig(level=logging.INFO)
+
     reader = S3Reader(bucket, key)
     cog = COGTiff(reader.read)
     mime_type, tile = cog.get_tile(*xyz)
@@ -50,9 +55,13 @@ def s3(bucket, key, output, xyz):
               help='local output directory')
 @click.option('--xyz', type=click.INT, default=[0, 0, 0], nargs=3,
               help='xyz tile coordinates where z is the overview level')
+@click.option('--verbose', '-v', is_flag=True, help='Show logs')
 @click.version_option(version=cogdumper_version, message='%(version)s')
-def http(server, path, resource, output, xyz=None):
+def http(server, path, resource, output, xyz, verbose):
     """Read web hosted dataset."""
+    if verbose:
+        logging.basicConfig(level=logging.INFO)
+
     reader = HTTPReader(server, path, resource)
     cog = COGTiff(reader.read)
     mime_type, tile = cog.get_tile(*xyz)
@@ -74,9 +83,13 @@ def http(server, path, resource, output, xyz=None):
               help='local output directory')
 @click.option('--xyz', type=click.INT, default=[0, 0, 0], nargs=3,
               help='xyz tile coordinate where z is the overview level')
+@click.option('--verbose', '-v', is_flag=True, help='Show logs')
 @click.version_option(version=cogdumper_version, message='%(version)s')
-def file(file, output, xyz=None):
+def file(file, output, xyz, verbose):
     """Read local dataset."""
+    if verbose:
+        logging.basicConfig(level=logging.INFO)
+
     with open(file, 'rb') as src:
         reader = FileReader(src)
         cog = COGTiff(reader.read)

--- a/tests/test_filedumper.py
+++ b/tests/test_filedumper.py
@@ -99,6 +99,19 @@ def test_tiff_tile(tiff):
     assert 73 == len(cog._image_ifds[0]['jpeg_tables'])
     assert mime_type == 'image/jpeg'
 
+
+def test_tiff_tile_env(tiff, monkeypatch):
+    monkeypatch.setenv("COG_INGESTED_BYTES_AT_OPEN", "1024")
+    reader = FileReader(tiff)
+    cog = COGTiff(reader.read)
+    mime_type, tile = cog.get_tile(0, 0, 0)
+    assert 1 == len(cog._image_ifds[0]['offsets'])
+    assert 1 == len(cog._image_ifds[0]['byte_counts'])
+    assert 'jpeg_tables' in cog._image_ifds[0]
+    assert 73 == len(cog._image_ifds[0]['jpeg_tables'])
+    assert mime_type == 'image/jpeg'
+
+
 def test_bad_tiff_tile(tiff):
     reader = FileReader(tiff)
     cog = COGTiff(reader.read)

--- a/tests/test_filedumper.py
+++ b/tests/test_filedumper.py
@@ -66,7 +66,6 @@ def test_tiff_ifds(tiff):
     reader = FileReader(tiff)
     cog = COGTiff(reader.read)
     # read private variable directly for testing
-    cog.read_header()
     assert len(cog._image_ifds) > 0
     assert 8 == len(cog._image_ifds[0]['tags'])
     assert 0 == cog._image_ifds[4]['next_offset']
@@ -76,7 +75,6 @@ def test_be_tiff_ifds(be_tiff):
     reader = FileReader(be_tiff)
     cog = COGTiff(reader.read)
     # read private variable directly for testing
-    cog.read_header()
     assert len(cog._image_ifds) > 0
     assert 8 == len(cog._image_ifds[0]['tags'])
     assert 0 == cog._image_ifds[4]['next_offset']
@@ -86,7 +84,6 @@ def test_bigtiff_ifds(bigtiff):
     reader = FileReader(bigtiff)
     cog = COGTiff(reader.read)
     # read private variable directly for testing
-    cog.read_header()
     assert len(cog._image_ifds) > 0
     assert 7 == len(cog._image_ifds[0]['tags'])
     assert 0 == cog._image_ifds[4]['next_offset']


### PR DESCRIPTION
closes #4 
This PR try to implement `chunk` reading for header retrieval to limit the number of `read` calls

### To Do
Right now I'm reading the first 8000 bytes of a file and decode the header. It works for normal TIFF but not for BIGTIFF. @normanb do you now if there is a size limit for GeoTIFF headers ? 